### PR TITLE
fix: default to files:read scope for Figma provider (#1831)

### DIFF
--- a/internal/api/external_figma_test.go
+++ b/internal/api/external_figma_test.go
@@ -27,7 +27,7 @@ func (ts *ExternalTestSuite) TestSignupExternalFigma() {
 	ts.Equal(ts.Config.External.Figma.RedirectURI, q.Get("redirect_uri"))
 	ts.Equal(ts.Config.External.Figma.ClientID, []string{q.Get("client_id")})
 	ts.Equal("code", q.Get("response_type"))
-	ts.Equal("file_read", q.Get("scope"))
+	ts.Equal("files:read", q.Get("scope"))
 
 	claims := ExternalProviderClaims{}
 	p := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}))

--- a/internal/api/provider/figma.go
+++ b/internal/api/provider/figma.go
@@ -37,9 +37,8 @@ func NewFigmaProvider(ext conf.OAuthProviderConfiguration, scopes string) (OAuth
 	authHost := chooseHost(ext.URL, defaultFigmaAuthBase)
 	apiHost := chooseHost(ext.URL, defaultFigmaAPIBase)
 
-	// Figma only provides the "file_read" scope.
 	oauthScopes := []string{
-		"file_read",
+		"files:read",
 	}
 
 	if scopes != "" {


### PR DESCRIPTION
Closes #1827 by defaulting to `files:read` oAuth scope for Figma as per the issue.